### PR TITLE
Problem: our components use random czmq in profile.xml

### DIFF
--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -8,7 +8,7 @@ set -ex
 # Verify all required dependencies with repos can be checked out
 cd "$REPO_DIR/.."
 git clone --quiet --depth 1 https://github.com/zeromq/libzmq.git libzmq
-git clone --quiet --depth 1 -b v3.0.2 https://github.com/zeromq/czmq.git czmq
+git clone --quiet --depth 1 -b v3.0.2 https://github.com/42ity/czmq.git czmq
 git clone --quiet --depth 1 https://github.com/zeromq/malamute.git malamute
 git clone --quiet --depth 1 https://github.com/42ity/fty-proto fty-proto
 cd -

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -210,7 +210,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         echo ""
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'czmq' from Git repository..." >&2
-        $CI_TIME git clone --quiet --depth 1 -b v3.0.2 https://github.com/zeromq/czmq.git czmq
+        $CI_TIME git clone --quiet --depth 1 -b v3.0.2 https://github.com/42ity/czmq.git czmq
         cd czmq
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR

--- a/configure.ac
+++ b/configure.ac
@@ -209,14 +209,14 @@ AS_IF([test x"${search_libczmq}" = xyes], [
 
     found_pkgconfig=""
     found_linkname=""
-    PKG_CHECK_MODULES([czmq], [libczmq >= 0.0.0],
+    PKG_CHECK_MODULES([czmq], [libczmq >= 3.0.0],
     [
         PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $czmq_LIBS"
         was_czmq_check_lib_detected=pkgcfg
         found_pkgconfig="libczmq"
     ],
     [
-        AC_MSG_NOTICE([Package libczmq not found; falling back to defined compilability tests])
+        AC_MSG_NOTICE([Package libczmq not found with needed constraints; falling back to defined compilability tests])
 
         czmq_synthetic_cflags=""
         czmq_synthetic_libs="-lczmq"
@@ -261,7 +261,7 @@ dnl END of PKG_CHECK_MODULES and/or direct tests for libczmq
             ],
         [xno], [
                 AC_SUBST([pkgconfig_name_libczmq],[libczmq])
-            AC_MSG_ERROR([Cannot find pkg-config metadata for libczmq 0.0.0 or higher])
+            AC_MSG_ERROR([Cannot find pkg-config metadata for libczmq 3.0.0 or higher])
     ])
 ])
 dnl END of enabled attempts to search for libczmq

--- a/project.xml
+++ b/project.xml
@@ -16,7 +16,8 @@
     <version major = "1" minor = "0" patch = "0" />
     <abi current = "1" revision = "0" age = "0" />
 
-    <use project = "czmq" release="v3.0.2" />
+    <use project = "czmq" min_major = "3" release = "v3.0.2"
+        repository="https://github.com/42ity/czmq.git"/>
     <use project = "malamute" />
     <use project = "fty-proto" libname = "libfty_proto" header="ftyproto.h"
         min_major = "1" min_minor = "0" min_patch = "0"

--- a/src/libfty_sensor_env.pc.in
+++ b/src/libfty_sensor_env.pc.in
@@ -12,7 +12,7 @@ Name: libfty_sensor_env
 Description: Grab temperature and humidity data from sensors attached to the box
 Version: @VERSION@
 
-Requires:@pkgconfig_name_libzmq@ @pkgconfig_name_libczmq@ @pkgconfig_name_libmlm@ @pkgconfig_name_libfty_proto@ >= 1.0.0
+Requires:@pkgconfig_name_libzmq@ @pkgconfig_name_libczmq@ >= 3.0.0 @pkgconfig_name_libmlm@ @pkgconfig_name_libfty_proto@ >= 1.0.0
 
 Libs: -L${libdir} -lfty_sensor_env
 Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
Solution: reference our fork of czmq branch v3.0.2 (vanilla + our few patches) in project.xml, and regenerate with modern zproject as a baseline. Impacts mostly just the consistency of Travis and common 42ity/FTY builds (our components' configure.ac should comply either way).