### PR TITLE
Problem: fty-sensor still uses old naming convention

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-# agent-th
+# fty-sensor-env
 
 Component sending temperature and humidity data from RackController's sensors
 connected to "TH" ports

--- a/include/fty_sensor_env.h
+++ b/include/fty_sensor_env.h
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    agent-th - Grab temperature and humidity data from some-sensor
+    fty-sensor-env - Grab temperature and humidity data from some-sensor
 
     Copyright (C) 2014 - 2017 Eaton
 

--- a/src/fty_sensor_env.cc
+++ b/src/fty_sensor_env.cc
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 /*!
- * \file agent-th.cc
+ * \file fty_sensor_env.cc
  * \author Michal Hrusecky <MichalHrusecky@Eaton.com>
  * \author Tomas Halman <TomasHalman@Eaton.com>
  * \author Jim Klimov <EvgenyKlimov@Eaton.com>

--- a/src/fty_sensor_env.cc
+++ b/src/fty_sensor_env.cc
@@ -41,7 +41,7 @@ bool agent_th_verbose = false;
     do { if (agent_th_verbose) zsys_debug (__VA_ARGS__); } while (0);
 
 // temporary
-#define HOSTNAME_FILE "/var/lib/fty/fty-sensor-env/agent_th"
+#define HOSTNAME_FILE "/var/lib/fty/fty-sensor-env/state"
 
 // strdup is to avoid -Werror=write-strings - not enough time to rewrite it properly
 // + it's going to be proprietary code ;-)


### PR DESCRIPTION
Solution: rename state file

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>