### PR TITLE
Problem: Need to support EMP001 on ports 1-8

### DIFF
--- a/include/fty_sensor_env.h
+++ b/include/fty_sensor_env.h
@@ -26,7 +26,8 @@
 #include "fty_sensor_env_library.h"
 
 //  Add your own public definitions here, if you need them
-#define PORTS_OFFSET                9   // ports range 9-12
+//#define PORTS_OFFSET                9   // T&H ports range 9-12
+#define PORTS_OFFSET                1 // consider ports 1-8 and 9-12
 #define POLLING_INTERVAL            5000
 #define TIME_TO_LIVE                300
 

--- a/src/fty_sensor_env_server.c
+++ b/src/fty_sensor_env_server.c
@@ -61,10 +61,22 @@ int testing = 0;
 #define read_gpi(...) \
     (unlikely(testing) ? 1 : read_gpi(__VA_ARGS__))
 
-#define PORTMAP_LENGTH 4
+#define PORTMAP_LENGTH 12
 const char *portmapping[2][PORTMAP_LENGTH] = {
-        { "/dev/ttySTH1", "/dev/ttySTH2", "/dev/ttySTH3", "/dev/ttySTH4" },
-        { "/dev/ttyS9",   "/dev/ttyS10",  "/dev/ttyS11",  "/dev/ttyS12"  } };
+        {
+            // standard serial ports which can be used for T&H too
+            // don't need/use the portmapping
+            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+            // Real T&H dedicated serial ports
+            "/dev/ttySTH1", "/dev/ttySTH2", "/dev/ttySTH3", "/dev/ttySTH4" },
+        {
+            // standard serial ports which can be used for T&H too
+            "/dev/ttyS1",   "/dev/ttyS2",   "/dev/ttyS3",   "/dev/ttyS4",
+            "/dev/ttyS5",   "/dev/ttyS6",   "/dev/ttyS7",   "/dev/ttyS8",
+            // Real T&H dedicated serial ports
+            "/dev/ttyS9",   "/dev/ttyS10",  "/dev/ttyS11",  "/dev/ttyS12"
+        }
+};
 
 typedef struct _c_item {
     int32_t T;


### PR DESCRIPTION
Solution: Extend the supported ports

Note that support of EMP001 on ports 1-8 also requires a special cable, since
the wiring of ports 1-8 (RS232) differs from the one of ports 9-12 (T&H
dedicated)

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit 0ddda46613480f2536362f7b6b741ecebcc6c1fd)